### PR TITLE
Remove requirements since charts are located in the repository.

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: grafana
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.17.5
-- name: prometheus
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 7.4.1
-digest: sha256:bab9fada328f41f9126b9e100b20499d4e6fa4aa5fecc8373f94c0fbe96db7e6
-generated: 2018-11-12T08:43:30.909455-07:00

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,8 +1,0 @@
----
-dependencies:
-  - name: "grafana"
-    version: "1.17.5"
-    repository: "@stable"
-  - name: "prometheus"
-    version: "7.4.1 "
-    repository: "@stable"


### PR DESCRIPTION
As of the PSP commit, you don't need these in the requirements file anymore, and avoids issues from users that might accidentally run `helm dependency update`